### PR TITLE
feat(map): switch Leaflet basemap from OSM to Carto Voyager

### DIFF
--- a/src/components/map/ExposureMap.jsx
+++ b/src/components/map/ExposureMap.jsx
@@ -137,7 +137,8 @@ const ExposureMap = () => {
       style={{ height: "100%", width: "100%" }}
     >
       <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
         maxZoom={15}
         minZoom={5}
       />

--- a/src/components/map/HazardMap.jsx
+++ b/src/components/map/HazardMap.jsx
@@ -201,7 +201,8 @@ const HazardMap = () => {
       style={{ position: "relative", height: "100%", width: "100%" }}
     >
       <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
         maxZoom={15}
         minZoom={5}
       />

--- a/src/components/map/RiskMap.jsx
+++ b/src/components/map/RiskMap.jsx
@@ -217,7 +217,8 @@ const RiskMap = () => {
       style={{ position: "relative", height: "100%", width: "100%" }}
     >
       <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
         maxZoom={15}
         minZoom={5}
       />


### PR DESCRIPTION
## Summary

- Replace deprecated `{s}.tile.openstreetmap.org` tile URL with Carto Voyager CDN in all three map components (Exposure, Hazard, Risk).
- Add required `attribution` prop crediting both OpenStreetMap and CARTO.
- Resolves OSM tile-policy violation (RISK WISE is a distributed Electron app, which the OSM policy explicitly forbids from heavy use) and eliminates the "Access blocked" placeholder tiles previously observed in production.

## Test plan

Static checks (verified):
- [x] `grep` confirms no `tile.openstreetmap.org` remains under `src/`.
- [x] All three files contain `basemaps.cartocdn.com/rastertiles/voyager`.
- [x] All three `TileLayer` elements have an `attribution` prop containing `OpenStreetMap` and `CARTO`.
- [x] Only the three intended files modified (`git diff --stat main` shows 3 files, 6 insertions, 3 deletions).
- [x] `npm run build` succeeds with no new warnings or errors.
- [ ] ESLint — project has no `eslint.config.js` (ESLint is in devDependencies but not configured), so this acceptance criterion cannot be executed. Pre-existing project state, unrelated to this change.

Manual verification (to be performed by reviewer before merge):
- [ ] `npm run dev` (or `npm run quickstart`); open Exposure / Hazard / Risk maps and confirm tiles render across zoom 5–15 with no "Access blocked" tile.
- [ ] Confirm "OpenStreetMap contributors © CARTO" attribution visible bottom-right on each map.
- [ ] Confirm `leaflet-simple-map-screenshoter` on Hazard and Risk maps still produces tiled images.

Resolves #45