### PR TITLE
fix(backend): five small scenario runner and base handler bugs

### DIFF
--- a/backend/base_handler.py
+++ b/backend/base_handler.py
@@ -227,7 +227,7 @@ class BaseHandler:
         if scenario == "rcp26":
             _scenario = "RCP 2.6"
         if scenario == "rcp45":
-            _scenario = "RCP 4.5"
+            _scenario = "RCP 4.5d"
         if scenario == "rcp60":
             _scenario = "RCP 6.0"
         if scenario == "rcp85":

--- a/backend/base_handler.py
+++ b/backend/base_handler.py
@@ -227,7 +227,7 @@ class BaseHandler:
         if scenario == "rcp26":
             _scenario = "RCP 2.6"
         if scenario == "rcp45":
-            _scenario = "RCP 4.5d"
+            _scenario = "RCP 4.5"
         if scenario == "rcp60":
             _scenario = "RCP 6.0"
         if scenario == "rcp85":

--- a/backend/run_scenario.py
+++ b/backend/run_scenario.py
@@ -130,8 +130,6 @@ class RunScenario:
         self.request_data = self._extract_request_data(request)
         # Set default successful status code and message
         self.status = Status()
-        # Clear previously generated maps and geojson datasets from temp directory
-        self._clear()
 
     def _initialize_handlers(self):
         """Initialize handlers."""
@@ -236,6 +234,7 @@ class RunScenario:
         :return: The average annual growth rate.
         :rtype: float
         """
+        default_growth_rate = 0
         try:
             growth_rates = {
                 "Egypt": {
@@ -261,7 +260,6 @@ class RunScenario:
                 },
             }
             if self.request_data.is_era:
-                default_growth_rate = 0
                 country_growth_rates = growth_rates.get(self.request_data.country_name, {})
                 growth = country_growth_rates.get(
                     self.request_data.exposure_type, default_growth_rate
@@ -544,7 +542,6 @@ class RunScenario:
             self.base_handler.update_progress(
                 20, "Setting up Exposure objects from custom datasets..."
             )
-            exposure_present = entity_present.exposures
             exposure_future = None
             if self.request_data.scenario != "historical":
                 exposure_future = entity_future.exposures

--- a/public/electron.js
+++ b/public/electron.js
@@ -696,7 +696,7 @@ ipcMain.on("shutdown", () => {
 });
 
 ipcMain.on("reload", async () => {
-  log.info("[electron] reload CLIMADA App...");
+  log.info("[electron] reloading RISK WISE renderer...");
 
   if (global.pythonProcess && !global.pythonProcess.killed) {
     try {


### PR DESCRIPTION
## Summary

Five small, independent fixes for the v1.0.9 release — see #47 for the full diagnosis.

- **B1** [backend/run_scenario.py](backend/run_scenario.py): hoist `default_growth_rate = 0` out of the `is_era` branch so the `except` can return it on every path.
- **B2** [backend/run_scenario.py](backend/run_scenario.py): drop the unconditional `exposure_present = entity_present.exposures` at the end of `_run_custom_scenario` (dead in entity-file branch, `NameError` in API branch).
- **B3** [backend/run_scenario.py](backend/run_scenario.py): remove the duplicate `self._clear()` call in `__init__`.
- **B4** [backend/base_handler.py](backend/base_handler.py): fix `"RCP 4.5d"` → `"RCP 4.5"` typo in `beautify_scenario`.
- **B5** [public/electron.js](public/electron.js): replace stale `"reload CLIMADA App..."` log with `"reloading RISK WISE renderer..."`.

Diff: 3 files, +3/-6.

## Test plan

- [ ] `pylint --exit-zero --fail-under=9 backend/` — score not regressed vs. main.
- [ ] `npm run build` — completes with no new warnings/errors.
- [ ] ERA mode → Egypt → tropical-cyclone, `rcp45` future → map title shows `RCP 4.5` (no trailing `d`).
- [ ] ERA mode → Thailand → `rcp45` scenario → same title check.
- [ ] ERA mode → `historical` scenario → completes successfully.
- [ ] Reload cycle → `%APPDATA%/RISK WISE/logs/app.log` does not contain `CLIMADA App`.
- [ ] Explore mode → CLIMADA-API exposure path (B2) — verified by code review if not reproducible locally.

Resolves #47