### PR TITLE
fix(electron): harden Python IPC parser and tighten preload bridge

### DIFF
--- a/public/.eslintrc.json
+++ b/public/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "script"
+  },
+  "rules": {
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/public/electron.js
+++ b/public/electron.js
@@ -61,7 +61,7 @@ const updateLoaderMessage = (message) => {
   }
 };
 
-const downloadAndInstallEngine = async (loaderWindow) => {
+const downloadAndInstallEngine = async (_loaderWindow) => {
   const engineRoot = process.env.LOCALAPPDATA;
   if (!engineRoot) {
     throw new Error("Failed to resolve LOCALAPPDATA environment variable");
@@ -490,27 +490,32 @@ const runPythonScript = (mainWindow, scriptName, data) => {
         const rawData = buffer.substring(0, boundary);
         buffer = buffer.substring(boundary + 1);
 
-        if (rawData.trim().startsWith("{") || rawData.trim().startsWith("[")) {
-          try {
-            const response = JSON.parse(rawData);
-            if (response.type === "progress") {
-              // Only send progress if mainWindow exists and isn't destroyed
-              if (mainWindow && !mainWindow.isDestroyed()) {
-                mainWindow.webContents.send("progress", response);
-              }
-            } else {
-              global.pythonProcess.stdout.off("data", handleData);
-              if (response.success) {
-                resolve(response.result);
-              } else {
-                reject(new Error(response.error));
-              }
-            }
-          } catch (error) {
-            global.pythonProcess.stdout.off("data", handleData);
-            log.error("Error parsing Python stdout:", error.message);
-            reject(error);
+        if (rawData.trim() === "") {
+          boundary = buffer.indexOf("\n");
+          continue;
+        }
+
+        let response;
+        try {
+          response = JSON.parse(rawData);
+        } catch {
+          log.warn(`[python:stdout] ${rawData}`);
+          boundary = buffer.indexOf("\n");
+          continue;
+        }
+
+        if (response.type === "progress") {
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send("progress", response);
           }
+        } else {
+          global.pythonProcess.stdout.off("data", handleData);
+          if (response.success) {
+            resolve(response.result);
+          } else {
+            reject(new Error(response.error));
+          }
+          return;
         }
 
         boundary = buffer.indexOf("\n");
@@ -623,7 +628,7 @@ ipcMain.handle("clear-temp-dir", async () => {
 });
 
 // Handle save screenshot request
-ipcMain.handle("save-screenshot", async (event, { blob, filePath }) => {
+ipcMain.handle("save-screenshot", async (_event, { blob, filePath }) => {
   try {
     const buffer = Buffer.from(blob, "base64");
     const dir = path.dirname(filePath);
@@ -631,16 +636,16 @@ ipcMain.handle("save-screenshot", async (event, { blob, filePath }) => {
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(filePath, buffer);
 
-    event.sender.send("save-screenshot-reply", { success: true, filePath });
     log.info("[electron] screenshot saved:", filePath);
+    return { success: true, filePath };
   } catch (error) {
     log.error("[electron] failed to save screenshot:", error);
-    event.sender.send("save-screenshot-reply", { success: false, error: error.message });
+    return { success: false, error: error.message };
   }
 });
 
 // Handle folder copy request
-ipcMain.handle("copy-folder", async (event, { sourceFolder, destinationFolder }) => {
+ipcMain.handle("copy-folder", async (_event, { sourceFolder, destinationFolder }) => {
   try {
     fs.mkdirSync(destinationFolder, { recursive: true });
     const files = fs.readdirSync(sourceFolder);
@@ -651,26 +656,26 @@ ipcMain.handle("copy-folder", async (event, { sourceFolder, destinationFolder })
       fs.copyFileSync(sourcePath, destinationPath);
     }
 
-    event.sender.send("copy-folder-reply", { success: true, destinationFolder });
     log.info("[electron] folder copied:", sourceFolder, "->", destinationFolder);
+    return { success: true, destinationFolder };
   } catch (error) {
     log.error("[electron] failed to copy folder:", error);
-    event.sender.send("copy-folder-reply", { success: false, error: error.message });
+    return { success: false, error: error.message };
   }
 });
 
 // Handle copy file from temp folder request
-ipcMain.handle("copy-file", async (event, { sourcePath, destinationPath }) => {
+ipcMain.handle("copy-file", async (_event, { sourcePath, destinationPath }) => {
   try {
     const dir = path.dirname(destinationPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.copyFileSync(sourcePath, destinationPath);
 
-    event.sender.send("copy-file-reply", { success: true, destinationPath });
     log.info("[electron] file copied:", sourcePath, "->", destinationPath);
+    return { success: true, destinationPath };
   } catch (error) {
     log.error("[electron] failed to copy file:", error);
-    event.sender.send("copy-file-reply", { success: false, error: error.message });
+    return { success: false, error: error.message };
   }
 });
 

--- a/public/preload.js
+++ b/public/preload.js
@@ -5,17 +5,17 @@ contextBridge.exposeInMainWorld("electron", {
   fetchTempDir: () => ipcRenderer.invoke("fetch-temp-dir"),
   fetchReportDir: () => ipcRenderer.invoke("fetch-report-dir"),
   isDevelopmentEnv: () => ipcRenderer.invoke("is-development-env"),
-  on: (channel, callback) => ipcRenderer.on(channel, callback),
-  remove: (channel, callback) => ipcRenderer.removeListener(channel, callback),
   send: (channel, data) => ipcRenderer.send(channel, data),
+  subscribeProgress: (callback) => {
+    const listener = (_event, data) => callback(data);
+    ipcRenderer.on("progress", listener);
+    return () => ipcRenderer.removeListener("progress", listener);
+  },
   saveScreenshot: (blob, filePath) => ipcRenderer.invoke("save-screenshot", { blob, filePath }),
-  onSaveScreenshotReply: (callback) => ipcRenderer.on("save-screenshot-reply", callback),
   copyFile: (sourcePath, destinationPath) =>
     ipcRenderer.invoke("copy-file", { sourcePath, destinationPath }),
-  onCopyFileReply: (callback) => ipcRenderer.on("copy-file-reply", callback),
   copyFolder: (sourceFolder, destinationFolder) =>
     ipcRenderer.invoke("copy-folder", { sourceFolder, destinationFolder }),
-  onCopyFolderReply: (callback) => ipcRenderer.on("copy-folder-reply", callback),
   openReport: (reportPath) => ipcRenderer.invoke("open-report", reportPath),
 });
 

--- a/src/components/loaders/LoadModal.jsx
+++ b/src/components/loaders/LoadModal.jsx
@@ -19,17 +19,14 @@ const LoadModal = () => {
   const { isScenarioRunning, modalMessage, setModalMessage } = useStore();
 
   useEffect(() => {
-    const progressListener = (event, data) => {
-      setModalMessage(data.message);
-    };
-    try {
-      window.electron.on("progress", progressListener);
-      return () => {
-        window.electron.remove("progress", progressListener);
-      };
-    } catch (e) {
+    if (!window.electron?.subscribeProgress) {
       console.log("Not running in electron");
+      return;
     }
+    const unsubscribe = window.electron.subscribeProgress((data) => {
+      setModalMessage(data.message);
+    });
+    return unsubscribe;
   }, []);
 
   return (

--- a/src/components/loaders/Loader.jsx
+++ b/src/components/loaders/Loader.jsx
@@ -40,17 +40,14 @@ const Loader = () => {
   const { progress, setProgress } = useStore();
 
   useEffect(() => {
-    const handleProgress = (event, json) => {
-      setProgress(json.progress);
-    };
-    try {
-      electron.on("progress", handleProgress);
-      return () => {
-        electron.remove("progress", handleProgress);
-      };
-    } catch (e) {
+    if (!electron?.subscribeProgress) {
       console.log("Not running in electron");
+      return;
     }
+    const unsubscribe = electron.subscribeProgress((json) => {
+      setProgress(json.progress);
+    });
+    return unsubscribe;
   }, []);
 
   return (

--- a/src/utils/mapTools.js
+++ b/src/utils/mapTools.js
@@ -37,9 +37,24 @@ export const useMapTools = () => {
         .takeScreen("blob")
         .then((blob) => {
           const reader = new FileReader();
-          reader.onloadend = () => {
+          reader.onloadend = async () => {
             const base64data = reader.result.split(",")[1];
-            window.electron.saveScreenshot(base64data, filePath);
+            try {
+              const reply = await window.electron.saveScreenshot(base64data, filePath);
+              if (reply.success) {
+                setAlertMessage(`${t("alert_message_successful_screenshot")}::${reply.filePath}`);
+                setAlertSeverity("success");
+                setAlertShowMessage(true);
+                resolve(reply.filePath);
+              } else {
+                setAlertMessage(`${t("alert_message_error_screenshot")}: ${reply.error}`);
+                setAlertSeverity("error");
+                setAlertShowMessage(true);
+                reject(new Error(reply.error));
+              }
+            } catch (err) {
+              reject(err);
+            }
           };
           reader.readAsDataURL(blob);
         })
@@ -47,21 +62,6 @@ export const useMapTools = () => {
           console.error(e);
           reject(e); // Reject the promise if an error occurs
         });
-
-      // Listen for the save screenshot response
-      window.electron.onSaveScreenshotReply((event, { success, error, filePath }) => {
-        if (success) {
-          setAlertMessage(`${t("alert_message_successful_screenshot")}::${filePath}`);
-          setAlertSeverity("success");
-          setAlertShowMessage(true);
-          resolve(filePath); // Resolve the promise with the file path on success
-        } else {
-          setAlertMessage(`${t("alert_message_error_screenshot")}: ${error}`);
-          setAlertSeverity("error");
-          setAlertShowMessage(true);
-          reject(new Error(error)); // Reject the promise on error
-        }
-      });
     });
   };
 
@@ -174,46 +174,27 @@ export const useMapTools = () => {
     }
   };
 
-  const copyFolderToTemp = (sourceFolder) => {
-    return new Promise((resolve, reject) => {
-      // Get the temp folder path first
-      window.electron.fetchTempDir().then((tempFolder) => {
-        const destinationFolder = `${tempFolder}`;
-
-        // Invoke folder copy
-        window.electron.copyFolder(sourceFolder, destinationFolder);
-
-        // Listen for the response
-        window.electron.onCopyFolderReply((event, { success, error, destinationFolder }) => {
-          if (success) {
-            resolve(destinationFolder); // Resolve the promise on success
-          } else {
-            reject(new Error(error)); // Reject the promise on error
-          }
-        });
-      });
-    });
+  const copyFolderToTemp = async (sourceFolder) => {
+    const tempFolder = await window.electron.fetchTempDir();
+    const reply = await window.electron.copyFolder(sourceFolder, tempFolder);
+    if (reply.success) {
+      return reply.destinationFolder;
+    }
+    throw new Error(reply.error);
   };
 
-  const copyFileToReports = (sourcePath, destinationPath) => {
-    return new Promise((resolve, reject) => {
-      window.electron.copyFile(sourcePath, destinationPath);
-
-      // Listen for the copy file response
-      window.electron.onCopyFileReply((event, { success, error, destinationPath }) => {
-        if (success) {
-          setAlertMessage(t("alert_message_successful_copy_file"));
-          setAlertSeverity("success");
-          setAlertShowMessage(true);
-          resolve(destinationPath); // Resolve the promise with the destination path on success
-        } else {
-          setAlertMessage(`${t("alert_message_error_copy_file")}: ${error}`);
-          setAlertSeverity("error");
-          setAlertShowMessage(true);
-          reject(new Error(error)); // Reject the promise on error
-        }
-      });
-    });
+  const copyFileToReports = async (sourcePath, destinationPath) => {
+    const reply = await window.electron.copyFile(sourcePath, destinationPath);
+    if (reply.success) {
+      setAlertMessage(t("alert_message_successful_copy_file"));
+      setAlertSeverity("success");
+      setAlertShowMessage(true);
+      return reply.destinationPath;
+    }
+    setAlertMessage(`${t("alert_message_error_copy_file")}: ${reply.error}`);
+    setAlertSeverity("error");
+    setAlertShowMessage(true);
+    throw new Error(reply.error);
   };
 
   const reportExists = (reportId) => {


### PR DESCRIPTION
## Summary

Closes #48. Two related defects in the renderer ↔ Python-backend Electron glue, hardened together because they touch the same two files.

### P1 — IPC parser

[public/electron.js](public/electron.js) `runPythonScript` previously decided whether to attempt `JSON.parse` on each newline-delimited stdout frame using a `startsWith("{") || startsWith("[")` heuristic. Anything that did not match was silently dropped, and a partial non-JSON line could concatenate with the next real frame and cause the listener to hang.

- Replaced the heuristic with a `try { JSON.parse(rawData) } catch { ... }` per frame.
- On parse failure, log the raw line via `log.warn` with a `[python:stdout]` prefix and continue — do not reject the in-flight promise; do not mutate the buffer.
- Skip empty lines.
- Added an explicit `return` after the listener detaches and the promise settles, so subsequent buffered lines never race.

### P2 — Preload bridge

[public/preload.js](public/preload.js) previously exposed generic `on(channel, callback)` and `remove(channel, callback)`, letting the renderer subscribe to any IPC channel. It also exposed `onSaveScreenshotReply` / `onCopyFileReply` / `onCopyFolderReply` listener registrations with no symmetric removal, which leaked listeners for the lifetime of the BrowserWindow.

- Replaced `on`/`remove` with a closed `subscribeProgress(callback)` that is the only path to the `progress` channel; it returns an unsubscribe function and hides the raw IPC `event` from callers.
- Refactored `save-screenshot`, `copy-folder`, and `copy-file` IPC handlers to **return** the result from `ipcMain.handle` directly. The renderer now awaits the `invoke` promise and the listener pattern is gone entirely. (This was the preferred option in the issue — chosen because the audit found no caller that genuinely needs streamed replies.)
- Updated [src/components/loaders/LoadModal.jsx](src/components/loaders/LoadModal.jsx), [src/components/loaders/Loader.jsx](src/components/loaders/Loader.jsx), and [src/utils/mapTools.js](src/utils/mapTools.js) to the new APIs.
- Added a tiny [public/.eslintrc.json](public/.eslintrc.json) so the main-process file lints under the Node env (the existing eslintrc was scoped to `src/` and never covered `public/`).

## Test plan

- [x] `npx eslint --ext .js,.jsx public/electron.js public/preload.js src/components/loaders src/utils/mapTools.js` passes (the issue's listed lint command).
- [x] `npm run build` completes cleanly.
- [x] **Happy-path scenario run** — launch the app, run an ERA scenario for Egypt with rcp45; confirm the LoadModal updates progress and closes cleanly, and that the unified app log has no `[python:stdout]` warn lines (or if it does, the run still completed).
- [ ] **Stress the parser** — temporarily insert `print("hello from CLIMADA")` in `_run_era_scenario`, rebuild, run a scenario; confirm the run still completes and the app log shows `[python:stdout] hello from CLIMADA` at warn level. Revert the diagnostic print before merging.
- [ ] **Listener leak check** — DevTools console, exercise tab/language switches and a scenario run, verify the `progress` listener count stays at 0 (or 1 while LoadModal is mounted).
- [ ] **Screenshot/copy IPC** — exercise the report-export screenshot path; confirm the new return-from-invoke flow still works end-to-end.

## Considered but not pursued

- Mirroring the `"progress"` channel name as a shared constant across main/preload — out of scope; would require a new shared module just for one string.
- Throttling the `[python:stdout]` warn-log writes — kept the issue's explicit `log.warn` requirement; if real CLIMADA runs prove chatty, downgrading to `log.debug` is a one-line follow-up.

