### PR TITLE
chore(engine): decouple engine download from app release tag (engine-v1)

### DIFF
--- a/installer/installer.nsh
+++ b/installer/installer.nsh
@@ -1,9 +1,57 @@
+; ---------------------------------------------------------------------------
+; Engine artifact (Python + CLIMADA). KEEP IN SYNC with public/electron.js
+; (search ENGINE_RELEASE_TAG). The .sha256 sidecar contains a single line of
+; lowercase hex (64 chars) that must match the downloaded zip.
+; ---------------------------------------------------------------------------
+!define ENGINE_RELEASE_TAG "engine-v1"
+!define ENGINE_DOWNLOAD_URL "https://github.com/gkalomalos/ERA-Project_RISK-WISE/releases/download/${ENGINE_RELEASE_TAG}/RiskWiseEngine.zip"
+!define ENGINE_SHA256_URL "${ENGINE_DOWNLOAD_URL}.sha256"
+
 !include "FileFunc.nsh"
 !include "LogicLib.nsh"
 
 ; Force immediate detail pane updates
 !define MUI_FINISHPAGE_NOAUTOCLOSE
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
+
+; Strips whitespace/CR/LF and lowercases a hex hash string.
+Function NormalizeHash
+  Exch $R0
+  Push $R1
+  Push $R2
+  StrCpy $R1 ""
+  StrLen $R2 $R0
+  IntOp $R2 $R2 - 1
+  ${ForEach} $R3 0 $R2 + 1
+    StrCpy $R4 $R0 1 $R3
+    ${If} $R4 == " "
+    ${OrIf} $R4 == "$\r"
+    ${OrIf} $R4 == "$\n"
+    ${OrIf} $R4 == "$\t"
+      ; skip
+    ${Else}
+      ; lowercase A-F -> a-f
+      ${If} $R4 == "A"
+        StrCpy $R4 "a"
+      ${ElseIf} $R4 == "B"
+        StrCpy $R4 "b"
+      ${ElseIf} $R4 == "C"
+        StrCpy $R4 "c"
+      ${ElseIf} $R4 == "D"
+        StrCpy $R4 "d"
+      ${ElseIf} $R4 == "E"
+        StrCpy $R4 "e"
+      ${ElseIf} $R4 == "F"
+        StrCpy $R4 "f"
+      ${EndIf}
+      StrCpy $R1 "$R1$R4"
+    ${EndIf}
+  ${Next}
+  StrCpy $R0 $R1
+  Pop $R2
+  Pop $R1
+  Exch $R0
+FunctionEnd
 
 !macro customInit
   SetDetailsPrint both
@@ -58,7 +106,7 @@
     DetailPrint "  Archive size: ~500 MB"
     Sleep 800
     
-    StrCpy $3 "https://github.com/gkalomalos/ERA-Project_RISK-WISE/releases/download/v1.0.6/RiskWiseEngine.zip"
+    StrCpy $3 "${ENGINE_DOWNLOAD_URL}"
     
     nsExec::ExecToLog 'curl -L "$3" --output "$2"'
     Pop $4
@@ -76,6 +124,60 @@
     DetailPrint "✓ Download complete"
     Sleep 500
   ${EndIf}
+
+  DetailPrint ""
+  DetailPrint "Verifying engine archive integrity..."
+  Sleep 500
+
+  ; Fetch expected hash sidecar -> %TEMP%\RiskWiseEngine.zip.sha256
+  StrCpy $6 "$TEMP\RiskWiseEngine.zip.sha256"
+  Delete "$6"
+  nsExec::ExecToLog 'curl -L -f -s "${ENGINE_SHA256_URL}" --output "$6"'
+  Pop $4
+  ${If} $4 != 0
+    DetailPrint "✗ Failed to download SHA-256 sidecar (exit code: $4)"
+    MessageBox MB_ICONSTOP|MB_TOPMOST \
+      "Failed to download engine integrity sidecar (${ENGINE_SHA256_URL}).$\r$\nExit code: $4$\r$\nCheck internet connection and retry."
+    Goto done_engine
+  ${EndIf}
+
+  ; Compute actual hash with certutil (built into Windows since Win7)
+  nsExec::ExecToStack 'cmd /c "certutil -hashfile $\"$2$\" SHA256 | findstr /v $\":$\" | findstr /v hash"'
+  Pop $4
+  Pop $5
+  ${If} $4 != 0
+    DetailPrint "✗ certutil failed (exit code: $4)"
+    MessageBox MB_ICONSTOP|MB_TOPMOST "Failed to compute archive checksum. certutil exit: $4"
+    Goto done_engine
+  ${EndIf}
+
+  ; $5 = computed hash (uppercase, may contain whitespace). Read expected from sidecar into $7.
+  FileOpen $8 "$6" r
+  FileRead $8 $7
+  FileClose $8
+
+  ; Normalize: strip CR/LF/spaces, lowercase both.
+  Push $5
+  Call NormalizeHash
+  Pop $5
+  Push $7
+  Call NormalizeHash
+  Pop $7
+
+  ${If} $5 != $7
+    DetailPrint "✗ Engine archive SHA-256 mismatch"
+    DetailPrint "  expected: $7"
+    DetailPrint "  actual:   $5"
+    Delete "$2"
+    Delete "$6"
+    MessageBox MB_ICONSTOP|MB_TOPMOST \
+      "Engine archive failed integrity check (SHA-256 mismatch).$\r$\n$\r$\nThe download may be corrupted or tampered.$\r$\nPlease run the installer again."
+    Goto done_engine
+  ${EndIf}
+
+  DetailPrint "✓ Engine archive integrity verified"
+  Delete "$6"
+  Sleep 500
 
   ; Verify archive exists
   ${IfNot} ${FileExists} "$2"

--- a/installer/installer.nsh
+++ b/installer/installer.nsh
@@ -1,11 +1,10 @@
 ; ---------------------------------------------------------------------------
 ; Engine artifact (Python + CLIMADA). KEEP IN SYNC with public/electron.js
-; (search ENGINE_RELEASE_TAG). The .sha256 sidecar contains a single line of
-; lowercase hex (64 chars) that must match the downloaded zip.
+; (search ENGINE_RELEASE_TAG). When changing the engine, bump the tag here
+; AND in public/electron.js.
 ; ---------------------------------------------------------------------------
 !define ENGINE_RELEASE_TAG "engine-v1"
 !define ENGINE_DOWNLOAD_URL "https://github.com/gkalomalos/ERA-Project_RISK-WISE/releases/download/${ENGINE_RELEASE_TAG}/RiskWiseEngine.zip"
-!define ENGINE_SHA256_URL "${ENGINE_DOWNLOAD_URL}.sha256"
 
 !include "FileFunc.nsh"
 !include "LogicLib.nsh"
@@ -13,45 +12,6 @@
 ; Force immediate detail pane updates
 !define MUI_FINISHPAGE_NOAUTOCLOSE
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
-
-; Strips whitespace/CR/LF and lowercases a hex hash string.
-Function NormalizeHash
-  Exch $R0
-  Push $R1
-  Push $R2
-  StrCpy $R1 ""
-  StrLen $R2 $R0
-  IntOp $R2 $R2 - 1
-  ${ForEach} $R3 0 $R2 + 1
-    StrCpy $R4 $R0 1 $R3
-    ${If} $R4 == " "
-    ${OrIf} $R4 == "$\r"
-    ${OrIf} $R4 == "$\n"
-    ${OrIf} $R4 == "$\t"
-      ; skip
-    ${Else}
-      ; lowercase A-F -> a-f
-      ${If} $R4 == "A"
-        StrCpy $R4 "a"
-      ${ElseIf} $R4 == "B"
-        StrCpy $R4 "b"
-      ${ElseIf} $R4 == "C"
-        StrCpy $R4 "c"
-      ${ElseIf} $R4 == "D"
-        StrCpy $R4 "d"
-      ${ElseIf} $R4 == "E"
-        StrCpy $R4 "e"
-      ${ElseIf} $R4 == "F"
-        StrCpy $R4 "f"
-      ${EndIf}
-      StrCpy $R1 "$R1$R4"
-    ${EndIf}
-  ${Next}
-  StrCpy $R0 $R1
-  Pop $R2
-  Pop $R1
-  Exch $R0
-FunctionEnd
 
 !macro customInit
   SetDetailsPrint both
@@ -124,60 +84,6 @@ FunctionEnd
     DetailPrint "✓ Download complete"
     Sleep 500
   ${EndIf}
-
-  DetailPrint ""
-  DetailPrint "Verifying engine archive integrity..."
-  Sleep 500
-
-  ; Fetch expected hash sidecar -> %TEMP%\RiskWiseEngine.zip.sha256
-  StrCpy $6 "$TEMP\RiskWiseEngine.zip.sha256"
-  Delete "$6"
-  nsExec::ExecToLog 'curl -L -f -s "${ENGINE_SHA256_URL}" --output "$6"'
-  Pop $4
-  ${If} $4 != 0
-    DetailPrint "✗ Failed to download SHA-256 sidecar (exit code: $4)"
-    MessageBox MB_ICONSTOP|MB_TOPMOST \
-      "Failed to download engine integrity sidecar (${ENGINE_SHA256_URL}).$\r$\nExit code: $4$\r$\nCheck internet connection and retry."
-    Goto done_engine
-  ${EndIf}
-
-  ; Compute actual hash with certutil (built into Windows since Win7)
-  nsExec::ExecToStack 'cmd /c "certutil -hashfile $\"$2$\" SHA256 | findstr /v $\":$\" | findstr /v hash"'
-  Pop $4
-  Pop $5
-  ${If} $4 != 0
-    DetailPrint "✗ certutil failed (exit code: $4)"
-    MessageBox MB_ICONSTOP|MB_TOPMOST "Failed to compute archive checksum. certutil exit: $4"
-    Goto done_engine
-  ${EndIf}
-
-  ; $5 = computed hash (uppercase, may contain whitespace). Read expected from sidecar into $7.
-  FileOpen $8 "$6" r
-  FileRead $8 $7
-  FileClose $8
-
-  ; Normalize: strip CR/LF/spaces, lowercase both.
-  Push $5
-  Call NormalizeHash
-  Pop $5
-  Push $7
-  Call NormalizeHash
-  Pop $7
-
-  ${If} $5 != $7
-    DetailPrint "✗ Engine archive SHA-256 mismatch"
-    DetailPrint "  expected: $7"
-    DetailPrint "  actual:   $5"
-    Delete "$2"
-    Delete "$6"
-    MessageBox MB_ICONSTOP|MB_TOPMOST \
-      "Engine archive failed integrity check (SHA-256 mismatch).$\r$\n$\r$\nThe download may be corrupted or tampered.$\r$\nPlease run the installer again."
-    Goto done_engine
-  ${EndIf}
-
-  DetailPrint "✓ Engine archive integrity verified"
-  Delete "$6"
-  Sleep 500
 
   ; Verify archive exists
   ${IfNot} ${FileExists} "$2"

--- a/public/electron.js
+++ b/public/electron.js
@@ -5,6 +5,19 @@ const path = require("path");
 const fs = require("fs");
 const log = require("electron-log");
 
+// ---------------------------------------------------------------------------
+// Engine artifact (Python runtime + CLIMADA). Hosted on a dedicated release
+// tag, decoupled from app version tags, so app releases can be cleaned up
+// without breaking engine bootstrap.
+//
+// KEEP IN SYNC with installer/installer.nsh (search ENGINE_RELEASE_TAG).
+// When changing the engine, bump the tag here AND in the installer, then
+// update ENGINE_SHA256 to match the new archive.
+// ---------------------------------------------------------------------------
+const ENGINE_RELEASE_TAG = "engine-v1";
+const ENGINE_DOWNLOAD_URL = `https://github.com/gkalomalos/ERA-Project_RISK-WISE/releases/download/${ENGINE_RELEASE_TAG}/RiskWiseEngine.zip`;
+const ENGINE_SHA256_URL = `${ENGINE_DOWNLOAD_URL}.sha256`;
+
 global.pythonProcess = null;
 
 const basePath = app.getAppPath();
@@ -85,8 +98,7 @@ const downloadAndInstallEngine = async (_loaderWindow) => {
 
     // Use electron's net module
     const { net } = require("electron");
-    const engineUrl =
-      "https://github.com/gkalomalos/ERA-Project_RISK-WISE/releases/download/v1.0.6/RiskWiseEngine.zip";
+    const engineUrl = ENGINE_DOWNLOAD_URL;
 
     await new Promise((resolve, reject) => {
       const request = net.request(engineUrl);
@@ -154,6 +166,55 @@ const downloadAndInstallEngine = async (_loaderWindow) => {
         `Archive too small (${(archiveSize / 1024 / 1024).toFixed(2)} MB) - download failed`
       );
     }
+
+    updateLoaderMessage("Verifying engine archive...");
+    log.info("[electron] fetching expected SHA-256 from:", ENGINE_SHA256_URL);
+
+    const expectedSha256 = await new Promise((resolve, reject) => {
+      const req = net.request(ENGINE_SHA256_URL);
+      let body = "";
+      req.on("response", (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`SHA-256 sidecar returned HTTP ${res.statusCode}`));
+          return;
+        }
+        res.on("data", (chunk) => {
+          body += chunk.toString("utf8");
+        });
+        res.on("end", () => resolve(body.trim().toLowerCase()));
+        res.on("error", reject);
+      });
+      req.on("error", reject);
+      req.end();
+    });
+
+    if (!/^[a-f0-9]{64}$/.test(expectedSha256)) {
+      throw new Error(`Malformed SHA-256 sidecar contents: ${expectedSha256.slice(0, 80)}`);
+    }
+
+    const crypto = require("crypto");
+    const actualSha256 = await new Promise((resolve, reject) => {
+      const hash = crypto.createHash("sha256");
+      const stream = fs.createReadStream(archivePath);
+      stream.on("data", (chunk) => hash.update(chunk));
+      stream.on("end", () => resolve(hash.digest("hex")));
+      stream.on("error", reject);
+    });
+
+    if (actualSha256 !== expectedSha256) {
+      log.error(
+        `[electron] engine SHA-256 mismatch. expected=${expectedSha256} actual=${actualSha256}`
+      );
+      try {
+        fs.unlinkSync(archivePath);
+      } catch {
+        /* best-effort cleanup */
+      }
+      throw new Error(
+        "Engine archive integrity check failed (SHA-256 mismatch). The download may be corrupted or tampered. Please retry."
+      );
+    }
+    log.info("[electron] engine SHA-256 verified:", actualSha256);
 
     updateLoaderMessage("Extracting engine files...");
     log.info("[electron] Starting extraction...");

--- a/public/electron.js
+++ b/public/electron.js
@@ -11,12 +11,10 @@ const log = require("electron-log");
 // without breaking engine bootstrap.
 //
 // KEEP IN SYNC with installer/installer.nsh (search ENGINE_RELEASE_TAG).
-// When changing the engine, bump the tag here AND in the installer, then
-// update ENGINE_SHA256 to match the new archive.
+// When changing the engine, bump the tag here AND in the installer.
 // ---------------------------------------------------------------------------
 const ENGINE_RELEASE_TAG = "engine-v1";
 const ENGINE_DOWNLOAD_URL = `https://github.com/gkalomalos/ERA-Project_RISK-WISE/releases/download/${ENGINE_RELEASE_TAG}/RiskWiseEngine.zip`;
-const ENGINE_SHA256_URL = `${ENGINE_DOWNLOAD_URL}.sha256`;
 
 global.pythonProcess = null;
 
@@ -166,55 +164,6 @@ const downloadAndInstallEngine = async (_loaderWindow) => {
         `Archive too small (${(archiveSize / 1024 / 1024).toFixed(2)} MB) - download failed`
       );
     }
-
-    updateLoaderMessage("Verifying engine archive...");
-    log.info("[electron] fetching expected SHA-256 from:", ENGINE_SHA256_URL);
-
-    const expectedSha256 = await new Promise((resolve, reject) => {
-      const req = net.request(ENGINE_SHA256_URL);
-      let body = "";
-      req.on("response", (res) => {
-        if (res.statusCode !== 200) {
-          reject(new Error(`SHA-256 sidecar returned HTTP ${res.statusCode}`));
-          return;
-        }
-        res.on("data", (chunk) => {
-          body += chunk.toString("utf8");
-        });
-        res.on("end", () => resolve(body.trim().toLowerCase()));
-        res.on("error", reject);
-      });
-      req.on("error", reject);
-      req.end();
-    });
-
-    if (!/^[a-f0-9]{64}$/.test(expectedSha256)) {
-      throw new Error(`Malformed SHA-256 sidecar contents: ${expectedSha256.slice(0, 80)}`);
-    }
-
-    const crypto = require("crypto");
-    const actualSha256 = await new Promise((resolve, reject) => {
-      const hash = crypto.createHash("sha256");
-      const stream = fs.createReadStream(archivePath);
-      stream.on("data", (chunk) => hash.update(chunk));
-      stream.on("end", () => resolve(hash.digest("hex")));
-      stream.on("error", reject);
-    });
-
-    if (actualSha256 !== expectedSha256) {
-      log.error(
-        `[electron] engine SHA-256 mismatch. expected=${expectedSha256} actual=${actualSha256}`
-      );
-      try {
-        fs.unlinkSync(archivePath);
-      } catch {
-        /* best-effort cleanup */
-      }
-      throw new Error(
-        "Engine archive integrity check failed (SHA-256 mismatch). The download may be corrupted or tampered. Please retry."
-      );
-    }
-    log.info("[electron] engine SHA-256 verified:", actualSha256);
 
     updateLoaderMessage("Extracting engine files...");
     log.info("[electron] Starting extraction...");


### PR DESCRIPTION
## Summary

Decouples the ~882 MB Python engine archive (`RiskWiseEngine.zip`) from the app's `v1.0.6` release tag by pointing both bootstrap sites at a dedicated `engine-v1` release tag. App releases (`v1.0.x`) can now be cleaned up, retracted, or rebuilt without breaking engine bootstrap for new installers or existing installs that re-bootstrap.

Refs #52

> **Scope note:** SHA-256 integrity verification (originally part of #52) has been **descoped for now** at the maintainer's request — this PR is the decoupling only. See commit `0c34494`. Because the issue's full scope isn't met, this PR uses `Refs #52` (does not auto-close); decide separately whether to track integrity verification as a follow-up or close #52.

## Changes

**`public/electron.js`**
- Adds `ENGINE_RELEASE_TAG` + `ENGINE_DOWNLOAD_URL` `const`s at module top.
- `downloadAndInstallEngine` now downloads from `ENGINE_DOWNLOAD_URL` instead of the hard-pinned `v1.0.6` URL. No other behavior change.

**`installer/installer.nsh`**
- Adds `ENGINE_RELEASE_TAG` + `ENGINE_DOWNLOAD_URL` via `!define`.
- The download `StrCpy` now uses `${ENGINE_DOWNLOAD_URL}`.

## Verification

- `ESLINT_USE_FLAT_CONFIG=false npx eslint public/electron.js` → passes (exit 0)
- `npm run build` → passes (exit 0)
- `engine-v1` release exists with `RiskWiseEngine.zip` (verified pre-merge).

### Manual verification (human, Windows VM — not run in this PR)

- Fresh install via `npm run dist` → installer downloads the zip from `engine-v1` and lands `python.exe` in `%LOCALAPPDATA%\RiskWiseEngine`.
- Runtime re-bootstrap: delete `%LOCALAPPDATA%\RiskWiseEngine`, launch the app, confirm the engine downloads from `engine-v1` and the app starts.
