### PR TITLE
chore(release): v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## 1.0.9 - 2026-06-03
+
+### Changed
+
+- Decoupled the engine download from app release tags using a dedicated `engine-v1` release
+- Switched the Leaflet basemap from OpenStreetMap to Carto Voyager
+- Updated application and security dependencies
+
+### Fixed
+
+- Corrected `cred_output` macroeconomic data and removed `government_debt`
+- Hardened Python IPC parsing and tightened the Electron preload bridge
+- Improved reliability of the startup and progress loader
+- Fixed several scenario runner and base handler bugs
+
 ## 1.0.8 - 2025-12-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "RISK WISE",
   "description": "Desktop GUI application for fully probabilistic climate risk assessment tool CLIMADA. Provides a framework for users to combine exposure, hazard and vulnerability or impact data to calculate risk.",
   "author": "Sword Group <georgios.kalomalos@sword-group.com>",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "main": "build/electron.js",
   "homepage": ".",


### PR DESCRIPTION
## Summary

Release preparation for **v1.0.9**: version bump + CHANGELOG entry. Tagging `v1.0.9` after this merges triggers the Windows build/publish workflow (signed NSIS installer + `latest.yml` for auto-update).

## Changes

- `package.json`: version 1.0.8 → 1.0.9
- `CHANGELOG.md`: add the 1.0.9 entry (Keep a Changelog format, matching existing style)

## What's in v1.0.9 (since v1.0.8)

- Engine download decoupled from app release tags via the dedicated `engine-v1` release (#72)
- Leaflet basemap switched from OpenStreetMap to Carto Voyager (#46)
- electron-builder bumped to 26.7.0 + dist smoke-test (#74)
- Dependency/security updates (#67, #38, #40, #43, #37)
- `cred_output` macroeconomic data fix (#54), IPC/preload hardening (#51), scenario runner fixes (#50)
