### PR TITLE
chore(deps): bump tar to 7.5.20 (build-only path)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8867,9 +8867,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
Follow-up safe bump missed from #87. `tar` is a transitive dep under electron-builder → node-gyp, only exercised during native rebuild. npm resolved to 7.5.20 (one patch past Dependabot's 7.5.19 target). Supersedes #82.