### PR TITLE
chore(deps): pin transitive brace-expansion to 5.0.7 (high)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7189,9 +7189,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,10 @@
   },
   "overrides": {
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@types/react-dom": "^18.0.0",
+    "minimatch@10.2.5": {
+      "brace-expansion": "^5.0.7"
+    }
   },
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
Fixes the one high-severity **npm** Dependabot alert that a version bump alone can address without touching a direct dependency.

## Alert
| # | Package | Range | Patched | Severity |
|---|---|---|---|---|
| [#111](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/111) | brace-expansion | `>=3.0.0 <5.0.7` (CVE-2026-13149) | 5.0.7 | high |

## Why an override instead of a bump
`brace-expansion` isn't a direct dependency — it's transitive, and multiple incompatible majors coexist in the tree (1.x, 2.x, 5.x) pulled in by different `minimatch` versions:

- `minimatch@3.1.5` (eslint, eslint-plugin-react, `@electron/asar`) → `brace-expansion@1.1.12`
- `minimatch@9.0.9` / `minimatch@5.1.9` (`@electron/universal`, jake/filelist) → `brace-expansion@2.1.0`
- `minimatch@10.2.5` (electron-builder's `app-builder-lib`, direct dep) → `brace-expansion@5.0.6` ← **vulnerable instance**

A blanket `overrides.brace-expansion` would force the 1.x/2.x consumers onto an incompatible major and likely break glob matching for eslint/asar packaging. Instead this targets only the vulnerable path:

```json
"overrides": {
  "minimatch@10.2.5": {
    "brace-expansion": "^5.0.7"
  }
}
```

`minimatch@10.2.5` already declares `brace-expansion: ^5.0.5`, so `5.0.7` is a same-major patch bump, not a forced jump.

## Verification
- Dev-only path (electron-builder packaging), never reachable from app runtime
- `npm ls brace-expansion` confirms only the targeted instance moved (5.0.6 → 5.0.7); the 1.1.12/2.1.0 instances are untouched
- `npm run build` succeeds

Addresses Dependabot alert #111.