### PR TITLE
chore(deps): bump setuptools, wheel, geopandas (pip, high severity)

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,9 +1,9 @@
 numpy==2.1.2
 pandas==2.2.3
-setuptools==75.1.0
-wheel==0.44.0
+setuptools==78.1.1
+wheel==0.46.2
 matplotlib==3.9.2
-geopandas==1.0.1
+geopandas==1.1.2
 shapely==2.0.6
 XlsxWriter==3.2.0
 pycountry==24.6.1


### PR DESCRIPTION
Bundles the three high-severity **pip** Dependabot alerts that are safe patch/minor bumps on `requirements/requirements.txt`.

## Alerts
| # | Package | Bump | CVE | Why safe |
|---|---|---|---|---|
| [#11](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/11) | setuptools | 75.1.0 → 78.1.1 | CVE-2025-47273 (path traversal → arbitrary file write in `PackageIndex.download`) | Build-time only, not imported by app code |
| [#15](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/15) | wheel | 0.44.0 → 0.46.2 | CVE-2026-24049 (path traversal in `wheel unpack`) | Build-time only, not imported by app code |
| [#18](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/18) | geopandas | 1.0.1 → 1.1.2 | CVE-2025-69662 (SQL injection in `to_postgis()`) | `to_postgis` isn't called anywhere in `backend/` |

## Compatibility check
- Grepped `backend/` for `import setuptools`, `pkg_resources`, `import wheel` — no hits, confirms these are pure build-time deps here.
- Grepped for `geom_almost_equals` / `GeoSeries.select` (the only two things removed between geopandas 1.0 and 1.1) — no hits.
- Checked PyPI metadata: `climada==4.1.1` declares no upper bound on `geopandas`, so this bump doesn't create a resolver conflict. geopandas 1.1.2's `numpy>=1.24`/`pandas>=2.0.0`/`shapely>=2.0.0`/`requires-python>=3.10` are all already satisfied by this repo's existing pins (`numpy==2.1.2`, `pandas==2.2.3`, `shapely==2.0.6`).

## Verification limits (please read before merging)
This sandbox has no conda available, and the backend's Python env (`requirements/environment.yml`, CLIMADA + GDAL/cartopy stack) can't be installed here. So this was checked at the **dependency-metadata level** (PyPI `requires_dist`/`requires_python`, changelog diff, and static grep for affected APIs) rather than an actual `pip install` + run of `backend/*/test_*.py`. Recommend running the backend test suite locally in the real conda env before merging, since that's a check I could not perform.

Addresses Dependabot alerts #11, #15, #18.