### PR TITLE
chore(deps): bump electron 37.3.1 -> 39.8.10 (high severity, needs manual smoke-test)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@vitejs/plugin-react": "4.3.2",
         "cross-env": "^10.0.0",
-        "electron": "37.3.1",
+        "electron": "39.8.10",
         "electron-builder": "26.7.0",
         "eslint": "9.39.2",
         "eslint-plugin-react": "7.37.5",
@@ -4620,9 +4620,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "37.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.3.1.tgz",
-      "integrity": "sha512-7DhktRLqhe6OJh/Bo75bTI0puUYEmIwSzMinocgO63mx3MVjtIn2tYMzLmAleNIlud2htkjpsMG2zT4PiTCloA==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@vitejs/plugin-react": "4.3.2",
     "cross-env": "^10.0.0",
-    "electron": "37.3.1",
+    "electron": "39.8.10",
     "electron-builder": "26.7.0",
     "eslint": "9.39.2",
     "eslint-plugin-react": "7.37.5",


### PR DESCRIPTION
Bumps Electron across two majors to fix 4 high-severity Dependabot alerts (plus 12 lower-severity ones for free, same target version) — this one carries real risk and I want that visible rather than papered over, so please read the verification-gap section before merging.

## High-severity alerts fixed
| # | CVE | Summary | Fixed in |
|---|---|---|---|
| [#61](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/61) | CVE-2026-34774 | UAF in offscreen child window paint callback | 39.8.1 |
| [#65](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/65) | CVE-2026-34771 | UAF in WebContents fullscreen/pointer-lock/keyboard-lock permission callbacks | 38.8.6 |
| [#57](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/57) | CVE-2026-34770 | UAF in PowerMonitor (Windows/macOS) | 38.8.6 |
| [#49](https://github.com/gkalomalos/ERA-Project_RISK-WISE/security/dependabot/49) | CVE-2026-34769 | Renderer command-line switch injection via undocumented `commandLineSwitches` webPreference | 38.8.6 |

None of these have a fix backported to 37.x, so a same-major patch isn't possible — alert #61 specifically requires 39.x. Pinned to **39.8.10** (latest 39.x patch) rather than the minimum 39.8.1, which also happens to close out the remaining lower-severity 38.x/39.x alerts on this dependency: #51, #53, #55, #59, #63, #67, #69, #71, #73, #75, #77, #79.

## Why I think this is safe
- Diffed this app's `public/electron.js` main process against the [Electron 38](https://www.electronjs.org/docs/latest/breaking-changes) and 39 breaking-changes docs. The only removals in those two majors: macOS 11 support, two Ozone/XDG Linux env vars, the `plugin-crashed` webContents event, `webFrame.routingId`. None used here — this is a Windows-only build (`build.win` is the only target in package.json).
- This app already runs `BrowserWindow` with `contextIsolation: true`, `sandbox: true`, `nodeIntegration: false` — the secure defaults these Electron majors don't change.
- `electron-builder@26.7.0` and `electron-updater@6.7.3` declare no peer-dependency constraint on the electron version (`npm view ... peerDependencies` — empty), so this isn't a packaging resolver conflict.
- `npm run build` (vite build, doesn't touch the electron binary) succeeds unchanged.

## Verification gap — please run before merging
This sandbox hits a known Schannel/network restriction on this dev machine for GitHub-hosted downloads: the Electron release zip downloads and its checksum validates correctly, but extraction hangs/aborts silently every time, so I could not get a working `electron .` process or run this repo's own packaging smoke-test (`npm run smoke-test`, i.e. `npm run dist && npm run verify-dist` — the same NSIS/zip/7z + `latest.yml` check built for the prior electron-builder bump in #74).

**This is the actual packaged runtime shipped to users** — higher blast radius than the vite/pip bumps in the other 3 PRs in this batch, which is why I'm flagging it explicitly rather than asserting it's fully verified. Recommend running `npm run smoke-test` on a normal machine (or let CI build it on `app_release.yml`'s tag trigger) before merging this one.

Addresses Dependabot alerts #49, #51, #53, #55, #57, #59, #61, #63, #65, #67, #69, #71, #73, #75, #77, #79.
